### PR TITLE
Emoji reaction to sysmsg #2

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -295,7 +295,6 @@ body {
 .message.system-message {
     background-color: #fff7cd;
     align-items: center;
-    display: flex;
     justify-content: center;
     color: #333;
 }


### PR DESCRIPTION
closes #2 

**style.css**  
Removed display: flex from the message.system-message class so the emojis show up correctly.

**Server.js**
Now pushes the System messages for a user joining or leaving, as well as there being a new host, into chatrooms.get(roomId).messages. Each System message now has a unique message ID, so that emojis can be added to the message.
If showPastMessages is enabled, the endIndex is now -1, so that the “user has joined the chat” message doesn’t show up twice for the person joining the room. 

![image](https://github.com/user-attachments/assets/16deb432-1378-4db7-8bdf-57e8dda8e25a)

